### PR TITLE
Use LINQ form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Fixed
 ### Changed
 - Dependencies - Updated Meziantou.Analyzer to 2.0.32
+- Instead of using Object.ReferenceEquals use ``is not`` operator
 ### Removed
 ### Deployment Changes
 

--- a/src/Credfeto.Extensions.Linq/EnumerableExtensions.cs
+++ b/src/Credfeto.Extensions.Linq/EnumerableExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Credfeto.Extensions.Linq;
 
@@ -7,24 +8,16 @@ public static class EnumerableExtensions
     public static IEnumerable<TItemType> RemoveNulls<TItemType>(this IEnumerable<TItemType?> source)
         where TItemType : class
     {
-        foreach (TItemType? item in source)
-        {
-            if (!ReferenceEquals(objA: item, objB: null))
-            {
-                yield return item;
-            }
-        }
+        return from TItemType? item in source
+               where item is not null
+               select item;
     }
 
     public static IEnumerable<TItemType> RemoveNulls<TItemType>(this IEnumerable<TItemType?> source)
         where TItemType : struct
     {
-        foreach (TItemType? item in source)
-        {
-            if (item.HasValue)
-            {
-                yield return item.Value;
-            }
-        }
+        return from TItemType? item in source
+               where item.HasValue
+               select item.Value;
     }
 }


### PR DESCRIPTION
Instead of using `Object.ReferenceEquals` it would be better to use `is not` operator which were introduced in C# 9. Since the target framework is 6.0 (uses C# 10 as default version) and 7.0 I think it would be safe bet. It's even more convenient to also use LINQ form.