### PR TITLE
fix: inline composite action logic in on_new_pr.yml to fix local action path resolution under pull_request_target

### DIFF
--- a/.github/workflows/on_new_pr.yml
+++ b/.github/workflows/on_new_pr.yml
@@ -6,6 +6,11 @@ on:
   # could and should work, at least for public repos;
   # tracking issue for this action's issue:
   # https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60
+  # NOTE: pull_request_target resolves local composite actions from the filesystem rather than git
+  # storage, and since the workspace is empty at job initialisation (before any steps run), local
+  # uses: ./.github/actions/... references will always fail — even with an actions/checkout step,
+  # because step execution happens after action path resolution. As a result, any steps in this
+  # workflow that would otherwise use local composite actions must inline their logic directly.
   pull_request_target:
     types:
       - opened
@@ -29,10 +34,33 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
       - name: "Auto Merge"
-        uses: ./.github/actions/enable-automerge
+        uses: actions/github-script@v9.0.0
         with:
           github-token: ${{secrets.SOURCE_PUSH_TOKEN}}
-          merge-method: "MERGE"
+          script: |
+            const mergeMethod = process.env.MERGE_METHOD;
+            const nodeId = context.payload.pull_request.node_id;
+            await github.graphql(`
+              mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: $mergeMethod
+                }) {
+                  pullRequest {
+                    autoMergeRequest {
+                      mergeMethod
+                    }
+                  }
+                }
+              }
+            `, {
+              pullRequestId: nodeId,
+              mergeMethod: mergeMethod,
+            });
+            core.info(`✅ Enabled auto-merge (${mergeMethod}) on PR #${context.payload.pull_request.number}`);
+            core.notice(`Enabled auto-merge (${mergeMethod}) on PR #${context.payload.pull_request.number}`);
+        env:
+          MERGE_METHOD: "MERGE"
 
   auto_approve_dependabot:
     runs-on: ubuntu-latest
@@ -44,6 +72,15 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
       - name: "Auto Approve"
-        uses: ./.github/actions/approve-pr
+        uses: actions/github-script@v9.0.0
         with:
           github-token: ${{secrets.SOURCE_PUSH_TOKEN}}
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE',
+            });
+            core.info(`✅ Approved PR #${context.payload.pull_request.number}`);
+            core.notice(`Approved PR #${context.payload.pull_request.number}`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 - Tests to increase coverage of Credfeto.Extensions.Linq to 100%
 ### Fixed
+- on_new_pr.yml: inline composite action logic to fix local action path resolution failure under pull_request_target
 ### Changed
 - Dependencies - Updated FunFair.CodeAnalysis to 7.2.1.2035
 - Dependencies - Updated Meziantou.Analyzer to 3.0.100


### PR DESCRIPTION
## Summary

- Replaces `uses: ./.github/actions/enable-automerge` and `uses: ./.github/actions/approve-pr` in both jobs of `on_new_pr.yml` with inlined `actions/github-script` steps.
- `pull_request_target` resolves local composite action paths from the filesystem **before any steps run**; since the workspace is empty at job initialisation, local `uses: ./.github/actions/...` references always fail — even after an `actions/checkout` step, because path resolution happens before step execution.
- The inlined logic is identical to the composite actions it replaces; the approach mirrors what was already applied in `approve-dependabot.yml`.

Closes #63

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Trigger a Dependabot PR with the `dependencies` label and confirm `enable-auto-merge` and `auto_approve_dependabot` checks both pass