### PR TITLE
fix: make ForEach ReadOnlySpan overload callable as an extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 ### Fixed
+- ForEach ReadOnlySpan overload is now callable as an extension method
 ### Changed
 - Dependencies - Updated FunFair.CodeAnalysis to 7.2.6.2145
 - Dependencies - Updated Meziantou.Analyzer to 3.0.121

--- a/src/Credfeto.Extensions.Linq.Tests/EnumerableExtensionsTests.cs
+++ b/src/Credfeto.Extensions.Linq.Tests/EnumerableExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FunFair.Test.Common;
@@ -64,6 +65,32 @@ public sealed class EnumerableExtensionsTests : TestBase
     public void ForEachEnumerableBranchTest()
     {
         IEnumerable<int> input = Enumerable.Range(start: 1, count: 3);
+
+        List<int> outputs = [];
+
+        input.ForEach(outputs.Add);
+
+        int[] expected = [1, 2, 3];
+
+        Assert.Equal(expected: expected, actual: outputs);
+    }
+
+    [Fact]
+    public void ForEachSpanEmptyTest()
+    {
+        ReadOnlySpan<int> input = [];
+
+        List<int> outputs = [];
+
+        input.ForEach(outputs.Add);
+
+        Assert.Empty(outputs);
+    }
+
+    [Fact]
+    public void ForEachSpanTest()
+    {
+        ReadOnlySpan<int> input = [1, 2, 3];
 
         List<int> outputs = [];
 

--- a/src/Credfeto.Extensions.Linq/EnumerableExtensions.cs
+++ b/src/Credfeto.Extensions.Linq/EnumerableExtensions.cs
@@ -57,7 +57,7 @@ public static class EnumerableExtensions
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [OverloadResolutionPriority(1)]
-    public static void ForEach<T>(in ReadOnlySpan<T> source, Action<T> action)
+    public static void ForEach<T>(this in ReadOnlySpan<T> source, Action<T> action)
     {
         ref T searchSpace = ref MemoryMarshal.GetReference(source);
 


### PR DESCRIPTION
## Summary

- Added `this` modifier to `EnumerableExtensions.ForEach<T>(in ReadOnlySpan<T>, Action<T>)` so callers can write `span.ForEach(action)` directly
- Added two new tests (`ForEachSpanEmptyTest` and `ForEachSpanTest`) covering empty and non-empty `ReadOnlySpan<int>` via extension method syntax
- Added `using System;` to the test file (required since implicit usings are disabled in the test project)

## Test plan

- [ ] `ForEachSpanEmptyTest` — verifies calling `ForEach` on an empty `ReadOnlySpan<int>` produces no side effects
- [ ] `ForEachSpanTest` — verifies calling `ForEach` on a `ReadOnlySpan<int>` with elements invokes the action for every element in order
- [ ] All 24 existing tests continue to pass on net9.0 and net10.0

Closes #75