### PR TITLE
fix: validate arguments on public Linq extension methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 - ForEach ReadOnlySpan overload is now callable as an extension method
+- Public extension methods now throw ArgumentNullException with the correct parameter name instead of a NullReferenceException when called with null arguments
 ### Changed
 - Dependencies - Updated SonarAnalyzer.CSharp to 10.28.0.143324
 - Dependencies - Updated FunFair.CodeAnalysis to 7.2.7.2152

--- a/src/Credfeto.Extensions.Linq.Tests/EnumerableExtensionsTests.cs
+++ b/src/Credfeto.Extensions.Linq.Tests/EnumerableExtensionsTests.cs
@@ -119,4 +119,74 @@ public sealed class EnumerableExtensionsTests : TestBase
         int? found = items.FirstOrNull(x => x == 7);
         Assert.Null(found);
     }
+
+    [Fact]
+    public void RemoveNullsClassShouldThrowWhenSourceIsNull()
+    {
+        IEnumerable<string?> source = null!;
+
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => source.RemoveNulls().ToArray());
+
+        Assert.Equal(expected: "source", actual: exception.ParamName);
+    }
+
+    [Fact]
+    public void RemoveNullsValueShouldThrowEagerlyWhenSourceIsNull()
+    {
+        IEnumerable<int?> source = null!;
+
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => source.RemoveNulls());
+
+        Assert.Equal(expected: "source", actual: exception.ParamName);
+    }
+
+    [Fact]
+    public void ForEachShouldThrowWhenEnumerationIsNull()
+    {
+        IEnumerable<int> enumeration = null!;
+
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => enumeration.ForEach(_ => { }));
+
+        Assert.Equal(expected: "enumeration", actual: exception.ParamName);
+    }
+
+    [Fact]
+    public void ForEachShouldThrowWhenActionIsNull()
+    {
+        int[] input = [1, 2, 3];
+
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => input.ForEach(null!));
+
+        Assert.Equal(expected: "action", actual: exception.ParamName);
+    }
+
+    [Fact]
+    public void ForEachSpanShouldThrowWhenActionIsNull()
+    {
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+            ((ReadOnlySpan<int>)[1, 2, 3]).ForEach(null!)
+        );
+
+        Assert.Equal(expected: "action", actual: exception.ParamName);
+    }
+
+    [Fact]
+    public void FirstOrNullShouldThrowWhenListIsNull()
+    {
+        IEnumerable<int> list = null!;
+
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => list.FirstOrNull(x => x == 1));
+
+        Assert.Equal(expected: "list", actual: exception.ParamName);
+    }
+
+    [Fact]
+    public void FirstOrNullShouldThrowWhenPredicateIsNull()
+    {
+        int[] items = [1, 2, 3];
+
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => items.FirstOrNull(null!));
+
+        Assert.Equal(expected: "predicate", actual: exception.ParamName);
+    }
 }

--- a/src/Credfeto.Extensions.Linq.Tests/SpanExtensionsTests.cs
+++ b/src/Credfeto.Extensions.Linq.Tests/SpanExtensionsTests.cs
@@ -25,4 +25,14 @@ public sealed class SpanExtensionsTests : TestBase
 
         Assert.Equal(expected: 10, actual: output);
     }
+
+    [Fact]
+    public void AggregateShouldThrowWhenFuncIsNull()
+    {
+        ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+            ((ReadOnlySpan<int>)[1, 2, 3]).Aggregate(seed: 0, func: null!)
+        );
+
+        Assert.Equal(expected: "func", actual: exception.ParamName);
+    }
 }

--- a/src/Credfeto.Extensions.Linq/EnumerableExtensions.cs
+++ b/src/Credfeto.Extensions.Linq/EnumerableExtensions.cs
@@ -16,17 +16,30 @@ public static class EnumerableExtensions
     public static IEnumerable<TItemType> RemoveNulls<TItemType>(this IEnumerable<TItemType?> source)
         where TItemType : class
     {
-        return from item in source where Item.Exists(item) select item;
+        ArgumentNullException.ThrowIfNull(source);
+
+        return from item in source
+            where Item.Exists(item)
+            select item;
     }
 
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IEnumerable<TItemType> RemoveNulls<TItemType>(this IEnumerable<TItemType?> source)
+        where TItemType : struct
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        return RemoveNullsIterator(source);
+    }
+
+    [Pure]
     [SuppressMessage(
         category: "SonarAnalyzer.CSharp",
         checkId: "S3267:Loops should be simplified with LINQ",
         Justification = "For performance reasons"
     )]
-    public static IEnumerable<TItemType> RemoveNulls<TItemType>(this IEnumerable<TItemType?> source)
+    private static IEnumerable<TItemType> RemoveNullsIterator<TItemType>(IEnumerable<TItemType?> source)
         where TItemType : struct
     {
         foreach (TItemType? item in source)
@@ -41,6 +54,9 @@ public static class EnumerableExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ForEach<T>(this IEnumerable<T> enumeration, Action<T> action)
     {
+        ArgumentNullException.ThrowIfNull(enumeration);
+        ArgumentNullException.ThrowIfNull(action);
+
         if (enumeration is List<T> list)
         {
             list.ForEach(action);
@@ -59,6 +75,8 @@ public static class EnumerableExtensions
     [OverloadResolutionPriority(1)]
     public static void ForEach<T>(this in ReadOnlySpan<T> source, Action<T> action)
     {
+        ArgumentNullException.ThrowIfNull(action);
+
         ref T searchSpace = ref MemoryMarshal.GetReference(source);
 
         for (int index = 0; index < source.Length; ++index)
@@ -80,6 +98,9 @@ public static class EnumerableExtensions
     public static TValue? FirstOrNull<TValue>(this IEnumerable<TValue> list, Func<TValue, bool> predicate)
         where TValue : struct
     {
+        ArgumentNullException.ThrowIfNull(list);
+        ArgumentNullException.ThrowIfNull(predicate);
+
         foreach (TValue item in list)
         {
             if (predicate(item))

--- a/src/Credfeto.Extensions.Linq/SpanExtensions.cs
+++ b/src/Credfeto.Extensions.Linq/SpanExtensions.cs
@@ -9,6 +9,8 @@ public static class SpanExtensions
     public static T Aggregate<T>(this in ReadOnlySpan<T> states, T seed, Func<T, T, T> func)
         where T : notnull
     {
+        ArgumentNullException.ThrowIfNull(func);
+
         T max = seed;
 
         foreach (T next in states)


### PR DESCRIPTION
## Summary

- Add `ArgumentNullException.ThrowIfNull` guards to the public entry points that previously surfaced a `NullReferenceException` from deep inside iteration instead of naming the offending parameter:
  - `EnumerableExtensions.RemoveNulls` (both the `class` and `struct` overloads)
  - `EnumerableExtensions.ForEach` (both the `IEnumerable<T>` and `ReadOnlySpan<T>` overloads)
  - `EnumerableExtensions.FirstOrNull`
  - `SpanExtensions.Aggregate`
- The `struct` `RemoveNulls` overload is split into a public validating wrapper plus a private `RemoveNullsIterator` so the null check is thrown eagerly at the call site rather than deferred to the first `MoveNext()`.
- Add tests asserting `ArgumentNullException` with the correct `ParamName` for each null-argument scenario.

Closes #76

## Test plan

- [x] `dotnet build` — solution builds cleanly (net9.0 and net10.0)
- [x] `dotnet test` — all 38 tests pass, including the new null-argument tests
- [x] Verified the `struct` `RemoveNulls` overload throws at the call site (before enumeration), not on first `MoveNext()`