### PR TITLE
chore: drop net9.0, target net10.0 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ﻿# Changelog
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 <!--
 Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
@@ -10,6 +13,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 ### Changed
+- Drop net9.0 support - target net10.0 only
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Extensions.Linq.Benchmarks.Tests/Credfeto.Extensions.Linq.Benchmarks.Tests.csproj
+++ b/src/Credfeto.Extensions.Linq.Benchmarks.Tests/Credfeto.Extensions.Linq.Benchmarks.Tests.csproj
@@ -28,7 +28,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Extensions.Linq.Tests/Credfeto.Extensions.Linq.Tests.csproj
+++ b/src/Credfeto.Extensions.Linq.Tests/Credfeto.Extensions.Linq.Tests.csproj
@@ -28,7 +28,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Extensions.Linq/Credfeto.Extensions.Linq.csproj
+++ b/src/Credfeto.Extensions.Linq/Credfeto.Extensions.Linq.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-extensions-linq</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />


### PR DESCRIPTION
## Summary

Drops `net9.0` from the multi-targeted projects, leaving `net10.0` as the sole `TargetFramework`, per the approved implementation plan on #83.

### Files to change (per plan)
- `src/Credfeto.Extensions.Linq/Credfeto.Extensions.Linq.csproj`
- `src/Credfeto.Extensions.Linq.Tests/Credfeto.Extensions.Linq.Tests.csproj`
- `src/Credfeto.Extensions.Linq.Benchmarks.Tests/Credfeto.Extensions.Linq.Benchmarks.Tests.csproj`

No `net9.0`-specific MSBuild `Condition`s, `#if NET9_0` (non-`_OR_GREATER`) guards, `global.json` SDK pins, or CI workflow pins were found referencing `net9.0`, so no additional cleanup is expected beyond the three `TargetFrameworks` edits.

This PR is currently a draft placeholder (changelog entry only) opened per the orchestrator workflow; the actual `.csproj` changes, build/test verification, and review passes happen on subsequent cycles.

## Test plan

- [ ] `dotnet buildcheck`, `dotnet build`, `dotnet test` pass with `net10.0` as the sole target framework
- [ ] Existing unit tests pass unmodified

Closes #83